### PR TITLE
[#1] passenger restart should be done by capistrano-passenger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+## [0.2.0] - 2018-08-28
+### Added
+- Look up .ruby-version from your local branch (cwd) if other options fail
+
+### Changed
+- Don't use Task#invoke!() to allow support of more capistrano versions (<3.8.2)
+- Update documentation to use other capistrano hook, so release_dir is available
+- .ruby-version lookup precedence now includes local branch (cwd)
+- Fixed a bug where capistrano exits if no ruby version has ever been installed using rbenv
+- Less verbose output while updating ruby-build plugin
+- If no :rbenv_roles have been provided, default to :all role
+
+## 0.1.0 - 2018-07-11
+### Added
+- Initial release.
+
+[0.2.0]: https://github.com/makandra/capistrano-opscomplete/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.3.0] - 2018-11-21
+### Removed
+- `appserver:restart` which restarts passenger was removed. Please use https://github.com/capistrano/passenger
+
 ## [0.2.0] - 2018-08-28
 ### Added
 - Look up .ruby-version from your local branch (cwd) if other options fail
@@ -15,3 +19,4 @@
 - Initial release.
 
 [0.2.0]: https://github.com/makandra/capistrano-opscomplete/compare/v0.1.0...v0.2.0
+[0.3.0]: https://github.com/makandra/capistrano-opscomplete/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -33,8 +33,6 @@ Now, add some [hooks](#using-capistrano-hooks) in your capistrano configuration.
 ```ruby
 # After unpacking your release, before bundling, compiling assets, ...
 after 'deploy:updating', 'opscomplete:ruby:ensure'
-# After your application has been successfully deployed and the current symlink has been set
-after 'deploy:published', 'opscomplete:appserver:restart'
 ```
 
 ## Usage
@@ -96,23 +94,12 @@ set :rbenv_roles, :web
 set :rbenv_roles, [:web, :worker]
 ```
 
-### opscomplete:appserver:restart
-
-To restart your application server execute:
-
-    $ bundle exec cap <ENVIRONMENT> opscomplete:appserver:restart
-
-Where `<ENVIRONMENT>` could be `production`, `staging**, ...
-
-**Note**: The current version of this gem only support the passenger app server. The current version of this gem does not support restarting your application, if multiple instances of passenger are running on the same host. This would be the case if you have Apache _and_ Nginx servers running on the same host.
-
 ### Using capistrano hooks
 
 There are many hooks available in the [default deploy flow](https://capistranorb.com/documentation/getting-started/flow/) to integrate tasks into your own deployment configuration. To ensure a ruby version according to your application is installed during deployment, add the following to your `Capfile`.
 
 ```ruby
 after 'deploy:updating', 'opscomplete:ruby:ensure'
-after 'deploy:published', 'opscomplete:appserver:restart'
 ```
 
 ## Contributing

--- a/lib/capistrano/opscomplete/tasks.rake
+++ b/lib/capistrano/opscomplete/tasks.rake
@@ -93,13 +93,4 @@ namespace :opscomplete do
       invoke('opscomplete:ruby:rehash') if fetch(:rbenv_needs_rehash, false)
     end
   end
-
-  namespace :appserver do
-    desc 'Restart Application'
-    task :restart do
-      on roles :app do
-        execute "sudo passenger-config restart-app --ignore-app-not-running #{fetch(:deploy_to)}"
-      end
-    end
-  end
 end

--- a/lib/capistrano/opscomplete/version.rb
+++ b/lib/capistrano/opscomplete/version.rb
@@ -1,5 +1,5 @@
 module Capistrano
   module Opscomplete
-    VERSION = '0.1.0'
+    VERSION = '0.2.0'
   end
 end


### PR DESCRIPTION
Remove passenger restart task. This shouldn't be part of capistrano-opscomplete.