### PR TITLE
Use :tmp_dir set in capistrano for rbenv install

### DIFF
--- a/lib/capistrano/opscomplete/tasks.rake
+++ b/lib/capistrano/opscomplete/tasks.rake
@@ -94,7 +94,9 @@ namespace :opscomplete do
           info("#{host}: Required ruby version '#{app_ruby_version}' is installed.")
         elsif rbenv_installable_rubies.include?(app_ruby_version)
           info("#{host}: Required ruby version is not installed, but available for installation.")
-          execute(:rbenv, :install, app_ruby_version)
+          with tmpdir: fetch(:tmp_dir) do
+            execute(:rbenv, :install, app_ruby_version)
+          end
           set :rbenv_needs_rehash, true
         else
           raise Capistrano::ValidationError,


### PR DESCRIPTION
I've encountered a server where `/tmp` is not allowed to hold executables (it's mounted with `noexec`).
This requires one to specify a custom `:tmpdir` setting in capistrano anyways, but it then still fails trying to install ruby.

This commit uses the same `:tmpdir` setting for `rbenv install` as well.