### PR TITLE
[#20] update rbenv_installable_rubies to rbenv-builds new behavior

### DIFF
--- a/lib/capistrano/dsl/opscomplete.rb
+++ b/lib/capistrano/dsl/opscomplete.rb
@@ -65,7 +65,7 @@ module Capistrano
       end
 
       def rbenv_installable_rubies
-        rbenv_installable_rubies = capture(:rbenv, :install, '--list').split("\n")
+        rbenv_installable_rubies = capture(:rbenv, :install, '--list-all').split("\n")
         rbenv_installable_rubies.map!(&:strip)
         rbenv_installable_rubies.delete('Available version:')
         rbenv_installable_rubies


### PR DESCRIPTION
Since a change in the rbenv-build plugin --list only shows the lastest versions (rbenv/ruby-build@67ac0b4).

Due to that it's currently not possible to install e.g. ruby 2.6.5 as only ruby 2.6.6 is shown:

```
$ rbenv install --list
2.5.8
2.6.6
2.7.1
jruby-9.2.11.1
maglev-1.0.0
mruby-2.1.0
rbx-4.15
truffleruby-20.1.0

Only latest stable releases for each Ruby implementation are shown.
Use 'rbenv install --list-all' to show all local versions.
```

As `opscomplete:ruby:update_ruby_build` is always called before `rbenv_installable_rubies` this should not break anything.

See: https://github.com/makandra/capistrano-opscomplete/blob/master/lib/capistrano/opscomplete/ruby.rake#L92
https://github.com/makandra/capistrano-opscomplete/blob/master/lib/capistrano/opscomplete/ruby.rake#L99

But it should get reviewed and tested first.

Closes #20 