### PR TITLE
Added missing namespace for code example

### DIFF
--- a/lib/capistrano/opscomplete/supervisor.rake
+++ b/lib/capistrano/opscomplete/supervisor.rake
@@ -36,7 +36,7 @@ namespace :opscomplete do
     #         on roles :cron do
     #           # The TSTP signal tells sidekiq to quiet all workers.
     #           # see: https://github.com/mperham/sidekiq/wiki/Signals#tstp
-    #           invoke('supervisor:signal_procs', 'TSTP', 'sidekiq')
+    #           invoke('opscomplete:supervisor:signal_procs', 'TSTP', 'sidekiq')
     #         end
     #       end
     #     end


### PR DESCRIPTION
Example for using the `signal_procs` was missing the namespace in front.