### PR TITLE
add posibillity to manage nodejs with capistrano-opscomplete

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,24 @@ There are many hooks available in the [default deploy flow](https://capistranorb
 after 'deploy:updating', 'opscomplete:ruby:ensure'
 ```
 
+## Managing your nodejs version with `capistrano-opscomplete`
+
+You can manage NodeJS also with `capistrano-opscomplete`. It will check the `.nvmrc`, `.node-version` and `.tool-versions` in the release direcotry (in this order) or you can configure it with `:opscomplete_nodejs_version` in your capistrano configuration.
+
+Include the gem in your applications Gemfile:
+
+```ruby
+gem 'capistrano-opscomplete'
+```
+
+Now, add some [hooks](#using-capistrano-hooks) in your capistrano configuration (e.g. `deploy.rb`).
+An example configuration could look like this:
+
+```ruby
+# After unpacking your release, before bundling, compiling assets, ...
+after 'deploy:updating', 'opscomplete:nodejs:ensure'
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome. Don't hesitate to [open a new issue](https://github.com/makandra/capistrano-opscomplete/issues/new).

--- a/lib/capistrano/dsl/opscomplete.rb
+++ b/lib/capistrano/dsl/opscomplete.rb
@@ -108,6 +108,38 @@ module Capistrano
       def rubygems_install(version)
         rbenv_exec("gem update --no-document --system '#{version}'")
       end
+
+      def managed_nodejs?
+        test("[ -f ${HOME}/.nodejs_managed_by_makandra ]")
+      end
+
+      def app_nodejs_version
+
+        # 1) Get version from capistrano configuration (highest precedence, 'override')
+        if fetch(:opscomplete_nodejs_version)
+          debug("Using version from :opscomplete_nodejs_version setting: #{fetch(:opscomplete_nodejs_version)}.")
+          fetch(:opscomplete_nodejs_version)
+
+        # 2) Get version from version file in release dir (after deploy:updating, before deploy:updated)
+        elsif capture(:nodejs_get_version, release_path)
+          debug("Using version from server's release_dir/.nvmrc, .node-version or .tool-versions file: #{capture(:nodejs_get_version, release_path)}")
+          capture(:nodejs_get_version, release_path)
+
+        else
+          raise Capistrano::ValidationError, 'Could not find application\'s Node.js version. Consider setting opscomplete_ruby_version.'
+        end
+      end
+
+      def nodejs_installable_versions
+        nodejs_installable_versions = capture(:nodejs_installable_versions).split("\n")
+        nodejs_installable_versions.map!(&:strip)
+        nodejs_installable_versions
+      end
+
+      def nodejs_installed_versions
+        nodejs_installed_versions = capture(:nodejs_installed_versions).split("\n")
+        nodejs_installed_versions.map!(&:strip)
+      end
     end
   end
 end

--- a/lib/capistrano/opscomplete.rb
+++ b/lib/capistrano/opscomplete.rb
@@ -4,4 +4,5 @@ require 'capistrano/opscomplete/version'
 require 'rake'
 
 load File.expand_path('opscomplete/ruby.rake', __dir__)
+load File.expand_path('opscomplete/nodejs.rake', __dir__)
 load File.expand_path('opscomplete/supervisor.rake', __dir__)

--- a/lib/capistrano/opscomplete/nodejs.rake
+++ b/lib/capistrano/opscomplete/nodejs.rake
@@ -1,0 +1,53 @@
+# vim: filetype=ruby
+require 'capistrano/dsl/opscomplete'
+
+namespace :opscomplete do
+  include Capistrano::DSL::Opscomplete
+  # desc 'Validate opscomplete specific configuration'
+  task :validate do
+    invoke('opscomplete:nodejs:check')
+  end
+
+  namespace :nodejs do
+    desc 'Check if nodejs version is set according to application\'s .node-version or .nvmrc (in this order).'
+    task :check do
+      on roles fetch(:nodejs_roles, :all) do |host|
+        warn("#{host}: Managed Node.js environment! Won't do any changes to nodejs version.") if managed_nodejs?
+        unless capture(:nodejs_current_version) == app_nodejs_version
+          raise Capistrano::ValidationError,
+                "#{host}: Node.js version is not set according to application\'s .node-version or .nvmrc file. Use cap opscomplete:nodejs:ensure."
+        end
+        info("#{host}: Node.js #{app_nodejs_version} is installed.")
+      end
+    end
+
+    desc 'Update Node.js version management tool'
+    task :update_nodejs_build do
+      on roles fetch(:nodejs_roles, :all) do
+        execute :nodejs_update_management_tool
+      end
+    end
+
+    desc 'Install and configure NodeJS according to applications .nvmrc, .node-version or .tool-versions.'
+    task :ensure do
+      invoke('opscomplete:nodejs:update_nodejs_build')
+      on roles fetch(:nodejs_roles, :all) do |host|
+        if managed_nodejs?
+          raise Capistrano::ValidationError, "#{host}: Managed Node.js environment! Won't do any changes to Node.js version."
+        end
+        if nodejs_installed_versions.include?(app_nodejs_version)
+          info("#{host}: Node.js #{app_nodejs_version} is installed.")
+        elsif nodejs_installable_versions.include?(app_nodejs_version)
+          info("#{host}: Configured Node.js version is not installed, but available for installation.")
+          with tmpdir: fetch(:tmp_dir) do
+            execute(:nodejs_install_version, "'#{app_nodejs_version}'")
+          end
+        else
+          raise Capistrano::ValidationError,
+                "#{host}: Configured Node.js version is neither installed nor installable."
+        end
+        execute(:nodejs_set_version, "'#{app_nodejs_version}'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
This commit adds the possibility to manage manage NodeJS via `.nvmrc`, `.node-version`, `.tool-versions` or capistration configuration.