### PR TITLE
Ruby rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ An example configuration could look like this:
 after 'deploy:updating', 'opscomplete:ruby:ensure'
 ```
 
-and in case you enabled [`Procfile support`](https://makandracards.com/opscomplete/67829-procfile-support) you can use the following tasks:
+If you want to handle the ruby version for rollbacks too, you should add:
+
+```ruby
+after 'deploy:reverting', 'opscomplete:ruby:ensure'
+```
+
+And in case you enabled [`Procfile support`](https://makandracards.com/opscomplete/67829-procfile-support) you can use the following tasks:
 
     opscomplete:supervisor:gen_config
     opscomplete:supervisor:restart_procs

--- a/lib/capistrano/opscomplete.rb
+++ b/lib/capistrano/opscomplete.rb
@@ -5,3 +5,4 @@ require 'rake'
 
 load File.expand_path('opscomplete/ruby.rake', __dir__)
 load File.expand_path('opscomplete/supervisor.rake', __dir__)
+load File.expand_path('../opscomplete/hooks.rb', __FILE__)

--- a/lib/capistrano/opscomplete/hooks.rb
+++ b/lib/capistrano/opscomplete/hooks.rb
@@ -1,0 +1,1 @@
+after 'deploy:failed', 'opscomplete:ruby:broken_gems_warning'


### PR DESCRIPTION
This PR mitigates the problems described in #19. 

We won't automatically rollback the ruby version after a fail, because we don't know in which state the server is at that moment or how difficult it is to solve the problem. Instead we warn, that there might be a problem if a ruby version update happened during a failed deploy and print information how the issues could be solved. 

- added a warning tasks which will be executed after `deploy:failed`: 

```
00:13 opscomplete:ruby:broken_gems_warning
      WARN  Deploy failed and the ruby version has been modified in this deploy.
      WARN  If this was a minor ruby version upgrade your running application may run into issues with native gem extensions.
      WARN  If your deploy failed deploy:symlink:release you may run bundle exec cap staging opscomplete:ruby:reset.
      WARN  Please refer https://makandracards.com/makandra/477884-bundler-in-deploy-mode-shares-gems-between-patch-level-ruby-versions
```

- added a reset task which sets the ruby version to the `.ruby-version` in `current_path` and runs `bundle pristine`

```
15:37:01 ⏚ [claus:~/code/makandra/capistrano-opscomplete_test] rollbacktest 1 ± bundle exec cap staging opscomplete:ruby:reset
00:00 opscomplete:ruby:reset
      01 rbenv global 2.7.1
    ✔ 01 deploy-capistrano-opscomplete_s@app01-stage.makandra.makandra.de 0.105s
      02 bundle pristine
      02 Installing rake 13.0.1
...
```

The referenced card must be updates after releasing the new features. 